### PR TITLE
Fixes for no-network install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,8 @@ test: .venv
 	#sudo apt-get install -qy libmacaroons0 python-macaroons libsodium13
 	# create virtualenv, install app deps
 	sudo apt-get install -qy python-virtualenv libpq-dev python-dev
-	virtualenv .venv
+	virtualenv --never-download .venv
 
-	$(PYHOME)/pip install --no-index -f deps/ pip==8.1.2
 	$(PYHOME)/pip install --no-index -f deps/ -r requirements.txt
 	$(PYHOME)/pip install --no-index -f deps/ -e .
 


### PR DESCRIPTION
This will no longer work on trusty due to the older version of pip
