### PR TITLE
Prevent test results table from changing width

### DIFF
--- a/reviewqueue/static/css/app.css
+++ b/reviewqueue/static/css/app.css
@@ -133,3 +133,6 @@ td.diff-comment {
   background-color: #ed3a3a;
   border-color: #ed3a3a;
 }
+.test-results {
+    table-layout: fixed;
+}

--- a/reviewqueue/templates/revision_tests/show.mako
+++ b/reviewqueue/templates/revision_tests/show.mako
@@ -1,6 +1,6 @@
 <%inherit file="../base.mako"/>
 
-<table class="table">
+<table class="table test-results">
   <thead>
     <tr>
       <th>Suite</th>


### PR DESCRIPTION
Fixes #36

Tested in Chrome and it automatically scrolls the details.  Should be tested in other browsers.
