### PR TITLE
Surface 'charm pull' errors.

### DIFF
--- a/reviewqueue/templates/reviews/new.mako
+++ b/reviewqueue/templates/reviews/new.mako
@@ -17,6 +17,9 @@
       <code>$ charm grant cs:~tvansteenburgh/meteor everyone</code>
     </div>
   </li>
+  <li>If your charm uses terms, release all terms using the <code>charm release-term</code>
+    command (<a href="https://jujucharms.com/docs/2.0/developer-terms#releasing-terms">docs</a>).
+  </li>
   <li>Are the owner of the charm, or a member of the team that owns the charm</li>
 </ul>
 

--- a/reviewqueue/views/reviews.py
+++ b/reviewqueue/views/reviews.py
@@ -225,6 +225,9 @@ def create(request):
         result['latest_revision_url'],
         request.registry.settings,
     )
+    # ensure review has an id
+    db.flush()
+
     return HTTPFound(
         location=request.route_url('reviews_show', id=review.id)
     )


### PR DESCRIPTION
Even when the charmstore api responds successfully to a revision url, there can be
subsequent problems retrieving the source for that revision using 'charm pull'.
Some of these can (and will) be handled gracefully by the app - for example, agreeing
to terms. But some require user intervention - for example, when the user has
failed to 'charm release-term' all the terms required.

This change surfaces such problems (specifically, any problem that occurs during a
'charm pull' or 'juju agree' that can not be automatically handled) to the user by
showing an error message on the review page (instead of the unhelpful 'Oops' message),
along with instructions for resolving the problem when possible.

Fixes #69.