### PR TITLE
Fix charmstore API URL to include "charmstore"

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -39,7 +39,7 @@ session.encrypt_key = randomstring
 session.secure = false
 
 base_url = https://8eefed73.ngrok.io
-charmstore.api.url = https://api.jujucharms.com/v5
+charmstore.api.url = https://api.jujucharms.com/charmstore/v5
 # charmstore.usso_token should be set to the base64-encoded value of a
 # charmstore oauth token, e.g. `base64 ~/.local/share/juju/store-usso-token`
 charmstore.usso_token =

--- a/production.ini
+++ b/production.ini
@@ -33,7 +33,7 @@ session.encrypt_key = randomstring
 session.secure = true
 
 base_url = http://localhost
-charmstore.api.url = https://api.jujucharms.com/v5
+charmstore.api.url = https://api.jujucharms.com/charmstore/v5
 # charmstore.usso_token should be set to the base64-encoded value of a
 # charmstore oauth token, e.g. `base64 ~/.local/share/juju/store-usso-token`
 charmstore.usso_token =


### PR DESCRIPTION
The Juju charmstore API lives at `https://api.jujucharms.com/charmstore/v5`. Whilst redirects are in place for the time being, eventually they will be dropped.